### PR TITLE
Workaround issue #23

### DIFF
--- a/src/lib/inc/libtimeit/db/TimeAccessor.h
+++ b/src/lib/inc/libtimeit/db/TimeAccessor.h
@@ -32,6 +32,7 @@ public:
 	virtual void                stopAllRunning() = 0;
 	virtual optional<TimeEntry> getByID(TimeID id) = 0;
 	virtual void                remove(TimeID id) = 0;
+	virtual void                removeShortTimeSpans() = 0;
 	virtual TimeList            getDetailTimeList(TaskID taskId,time_t startTime, time_t stopTime) = 0;
 	virtual TaskIDList          getLatestTasks(int amount) = 0;
 	virtual int	                getTime(int64_t taskID, time_t startTime, time_t stopTime) = 0;
@@ -57,6 +58,7 @@ public:
 	virtual TaskIDList          getLatestTasks(int amount);
 	virtual optional<TimeEntry> getByID(TimeID id);
 	virtual void                remove(TimeID id);
+	virtual void                removeShortTimeSpans();
 	virtual TimeList            getDetailTimeList(TaskID taskId,time_t startTime, time_t stopTime);
 	virtual int	                getTime(TaskID taskID, time_t startTime, time_t stopTime);
 	virtual TimeList            getTimesChangedSince(time_t timestamp=0);
@@ -65,12 +67,11 @@ public:
 	virtual TimeID              newEntry(const TimeEntry& item);
 	virtual time_t              getTotalTimeWithChildren(TaskID taskID, time_t start, time_t stop);
 	virtual TaskIDList          getRunningTasks();
-	virtual TaskIDList          getActiveTasks(time_t start, time_t stop) ;
+	virtual TaskIDList          getActiveTasks(time_t start, time_t stop);
 
 	void createTable();
 	void upgradeToDB5();
-    void createViews();
-    void removeShortTimeSpans();
+	void createViews();
 private:
 	std::shared_ptr<CSQL> db;
 	Notifier& notifier;

--- a/src/lib/src/DB/TimeAccessor.cpp
+++ b/src/lib/src/DB/TimeAccessor.cpp
@@ -55,6 +55,15 @@ void TimeAccessor::remove(int64_t id)
 	}
 }
 
+void TimeAccessor::removeShortTimeSpans()
+{
+	time_t now = time(nullptr);
+	Statement statement = db->prepare( // short, except if barely a moment ago
+			"DELETE FROM times WHERE stop-start < 30 AND ?-stop > 30");
+	statement.bindValue(1, now);
+	statement.execute();
+}
+
 std::optional<TimeEntry> TimeAccessor::getByID(int64_t id)
 {
 	Statement statement = db->prepare(
@@ -411,11 +420,6 @@ void TimeAccessor::createViews()
 			" FROM times "
 			" LEFT JOIN tasks "
 			" ON times.taskID = tasks.id");
-}
-
-void TimeAccessor::removeShortTimeSpans()
-{
-	db->exe("DELETE FROM times WHERE stop-start < 30");
 }
 
 std::vector<int64_t> TimeAccessor::getActiveTasks(time_t start, time_t stop)

--- a/src/tests/src/Mock/MockTimeAccessor.cpp
+++ b/src/tests/src/Mock/MockTimeAccessor.cpp
@@ -55,6 +55,10 @@ void MockTimeAccessor::remove(int64_t id)
 {
 }
 
+void MockTimeAccessor::removeShortTimeSpans()
+{
+}
+
 std::vector<TimeEntry> MockTimeAccessor::getDetailTimeList(int64_t taskId, time_t startTime, time_t stopTime)
 {
 	std::vector<TimeEntry> list

--- a/src/tests/src/Mock/MockTimeAccessor.h
+++ b/src/tests/src/Mock/MockTimeAccessor.h
@@ -26,6 +26,7 @@ public:
 	virtual void setRunning(int64_t timeID, bool running);
 	virtual std::optional<TimeEntry> getByID(int64_t id);
 	virtual void remove(int64_t id);
+	virtual void removeShortTimeSpans();
 	virtual std::vector<TimeEntry> getDetailTimeList(int64_t taskId,time_t startTime, time_t stopTime) ;
 	virtual std::vector<int64_t> getLatestTasks(int amount);
 	virtual int	getTime(int64_t taskID, time_t startTime, time_t stopTime);

--- a/src/timeit_gtkmm/GUI/DetailsDialog.cpp
+++ b/src/timeit_gtkmm/GUI/DetailsDialog.cpp
@@ -7,6 +7,7 @@
 
 #include "DetailsDialog.h"
 #include "libtimeit/Utils.h"
+#include <libtimeit/db/DefaultValues.h>
 #include <ctime>
 #include <glibmm/i18n.h>
 
@@ -26,7 +27,7 @@ DetailsDialog::DetailsDialog(shared_ptr<IDatabase>& database) :
 	detailList(database), table(4, 4), startTimeLabel(_("Start time")),
 			stopTimeLabel(_("Stop time")), CancelButton(Gtk::StockID(
 		"gtk-revert-to-saved")),
-OKButton(Gtk::StockID("gtk-apply")), timeAccessor(database->getTimeAccessor())
+OKButton(Gtk::StockID("gtk-apply")), timeAccessor(database->getTimeAccessor()), settingsAccessor(database->getSettingsAccessor())
 {
 	startTimeHour.set_range(0, 23);
 	startTimeMinute.set_range(0, 59);
@@ -154,6 +155,11 @@ void DetailsDialog::on_edit_details(int64_t id)
 
 void DetailsDialog::set(int64_t ID, time_t startTime, time_t stopTime)
 {
+	bool quiet = settingsAccessor->GetBoolByName("Quiet", DEFAULT_QUIET_MODE);
+	if (quiet) // only if needed as workaround to remove an unwanted flood of entries because of issue #23
+	{
+		timeAccessor->removeShortTimeSpans();
+	}
 	timeEntryID = 0;
 	id = ID;
 	rangeStart = startTime;

--- a/src/timeit_gtkmm/GUI/DetailsDialog.h
+++ b/src/timeit_gtkmm/GUI/DetailsDialog.h
@@ -12,6 +12,7 @@
 #include "LZSpinButton.h"
 #include "Details.h"
 #include "MainWindow/Summary.h"
+#include <libtimeit/db/ISettingsAccessor.h>
 #include <libtimeit/db/Database.h>
 #include <IWidget.h>
 
@@ -82,6 +83,7 @@ private:
 	int64_t timeEntryID;
 	std::weak_ptr<DetailsDialog> weak_this_ptr;
 	std::shared_ptr<ITimeAccessor> timeAccessor;
+	std::shared_ptr<libtimeit::ISettingsAccessor> settingsAccessor;
 };
 }
 

--- a/src/timeit_gtkmm/Tests/Mock/MockTimeAccessor.cpp
+++ b/src/timeit_gtkmm/Tests/Mock/MockTimeAccessor.cpp
@@ -55,6 +55,10 @@ void MockTimeAccessor::remove(int64_t id)
 {
 }
 
+void MockTimeAccessor::removeShortTimeSpans()
+{
+}
+
 std::vector<TimeEntry> MockTimeAccessor::getDetailTimeList(int64_t taskId, time_t startTime, time_t stopTime)
 {
 	std::vector<TimeEntry> list

--- a/src/timeit_gtkmm/Tests/Mock/MockTimeAccessor.h
+++ b/src/timeit_gtkmm/Tests/Mock/MockTimeAccessor.h
@@ -26,6 +26,7 @@ public:
 	virtual void setRunning(int64_t timeID, bool running);
 	virtual std::optional<TimeEntry> getByID(int64_t id);
 	virtual void remove(int64_t id);
+	virtual void removeShortTimeSpans();
 	virtual std::vector<TimeEntry> getDetailTimeList(int64_t taskId,time_t startTime, time_t stopTime) ;
 	virtual std::vector<int64_t> getLatestTasks(int amount);
 	virtual int	getTime(int64_t taskID, time_t startTime, time_t stopTime);


### PR DESCRIPTION
Make TimeIT showing details be usable when in quiet mode.

Before showing details remove short time spans.

Necessarily don't remove a very recent time span.

For least impact, only do this if in quiet mode.

This probably will become obsolete after a further rewrite.