### PR TITLE
Show taskname in details dialog

### DIFF
--- a/src/timeit_gtkmm/GUI/DetailsDialog.h
+++ b/src/timeit_gtkmm/GUI/DetailsDialog.h
@@ -44,7 +44,7 @@ public:
 	virtual bool is_visible() { return Gtk::Dialog::is_visible(); } ;
 	virtual void get_position(int& Window_x, int& Window_y) { Gtk::Dialog::get_position(Window_x, Window_y); };
 
-	void updateTitle();
+	void on_runningTasksChanged();
 
 private:
 	DetailsDialog(std::shared_ptr<IDatabase>& database);
@@ -55,7 +55,7 @@ private:
 
 	//DetailsObserver
 	void on_selected_changed();
-	void on_edit_details(int64_t id);
+	void on_edit_details(int64_t timeEntryID);
 
 	void setValues();
 	void on_OKButton_clicked();
@@ -63,8 +63,13 @@ private:
 	void on_change();
 	void checkForChanges();
 
+	Gtk::Table table1;
+	Gtk::Label taskName;
+	Gtk::Image runningImage;
+	Glib::RefPtr<Gdk::Pixbuf> runningIcon;
+	Glib::RefPtr<Gdk::Pixbuf> blankIcon;
 	Details detailList;
-	Gtk::Table table;
+	Gtk::Table table2;
 	Gtk::Label startTimeLabel;
 	Gtk::Label stopTimeLabel;
 	Gtk::Label startColonLabel, toLabel, stopColonLabel;
@@ -82,10 +87,11 @@ private:
 	time_t  stopTime;
 	time_t  rangeStart;
 	time_t  rangeStop;
-	int64_t id;
-	int64_t timeEntryID;
+	int64_t m_taskID;
+	int64_t m_timeEntryID;
 	std::weak_ptr<DetailsDialog> weak_this_ptr;
 	std::shared_ptr<ITimeAccessor> timeAccessor;
+	std::shared_ptr<IExtendedTaskAccessor> taskAccessor;
 };
 }
 

--- a/src/timeit_gtkmm/GUI/MainWindow/MainWindow.cpp
+++ b/src/timeit_gtkmm/GUI/MainWindow/MainWindow.cpp
@@ -55,7 +55,7 @@ MainWindow::MainWindow(std::shared_ptr<IDatabase> &database) :
 	relateWidgets();
 	attach(this);
 	show_all_children();
-	updateTitle();
+	on_runningTasksChanged();
 }
 
 ICalendar& MainWindow::getCalendar()
@@ -275,7 +275,7 @@ void MainWindow::classicLayout()
 	}
 }
 
-void MainWindow::updateTitle()
+void MainWindow::on_runningTasksChanged()
 {
 	std::vector<int64_t> taskIDs = timeAccessor->getRunningTasks();
 	if (taskIDs.size() > 0)

--- a/src/timeit_gtkmm/GUI/MainWindow/MainWindow.h
+++ b/src/timeit_gtkmm/GUI/MainWindow/MainWindow.h
@@ -79,7 +79,7 @@ public:
 
 	virtual void on_show();
 
-	void updateTitle();
+	void on_runningTasksChanged();
 
 private:
 	//Action observer

--- a/src/timeit_gtkmm/Logic/Controller.cpp
+++ b/src/timeit_gtkmm/Logic/Controller.cpp
@@ -247,9 +247,9 @@ void Controller::on_showDetailsClicked(ISummary* summary, int64_t taskId, time_t
 void Controller::on_runningChanged()
 {
 	std::shared_ptr<MainWindow> mainWindow = std::dynamic_pointer_cast<MainWindow>(guiFactory->getWidget(MAIN_WINDOW));
-	mainWindow->updateTitle();
+	mainWindow->on_runningTasksChanged();
 	std::shared_ptr<DetailsDialog> detailsDialog = std::dynamic_pointer_cast<DetailsDialog>(guiFactory->getWidget(DETAILS_DIALOG));
-	detailsDialog->updateTitle();
+	detailsDialog->on_runningTasksChanged();
 }
 void Controller::on_selection_changed(int64_t id, time_t startTime, time_t stopTime)
 {

--- a/src/timeit_gtkmm/Logic/TimeKeeper.cpp
+++ b/src/timeit_gtkmm/Logic/TimeKeeper.cpp
@@ -108,10 +108,7 @@ void Timekeeper::StartTask(int64_t id)
 		task.taskID = id;
 		activeTasks[id] = task;
 		m_timeAccessor->setRunning(task.dbHandle, true);
-		if (activeTasks.size() == 1)
-		{
-			notifyRunningChanged();
-		}
+		notifyRunningChanged();
 	}
 }
 
@@ -138,11 +135,7 @@ void Timekeeper::StopTask(int64_t id)
 		TaskTime task = it->second;
 		activeTasks.erase(it);
 		m_timeAccessor->setRunning(task.dbHandle, false);
-
-		if (activeTasks.empty() == true)
-		{
-			notifyRunningChanged();
-		}
+		notifyRunningChanged();
 	}
 }
 
@@ -153,10 +146,7 @@ void Timekeeper::on_taskRemoved(int64_t id)
 	if (it != activeTasks.end())
 	{
 		activeTasks.erase(it);
-		if (activeTasks.empty())
-		{
-			notifyRunningChanged();
-		}
+		notifyRunningChanged();
 	}
 }
 void Timekeeper::on_completeUpdate()


### PR DESCRIPTION
Also indicates whether that task is running.

The layout, alignment, padding etc. used for this in the details dialog should be revisited when switching to GTK 3.

Two goals had been:
- Allow the user to be sure what task they are looking at in the details dialog.
- Allow the user to quickly assert that task is still running, if user keeps the details dialog as their main view of the app during the workday.