### PR TITLE
Allow user to split a timespan

### DIFF
--- a/src/lib/src/DB/TimeAccessor.cpp
+++ b/src/lib/src/DB/TimeAccessor.cpp
@@ -215,6 +215,7 @@ TimeList TimeAccessor::getDetailTimeList(int64_t taskID, time_t startTime, time_
 	statement << " AND start <" << stopTime;
 	statement << " AND taskID = " << taskID;
 	statement << " AND deleted=0 ";
+	statement << " ORDER BY start";
 
 	QueryResult rows = database.exe(statement.str());
 	for (vector<DataCell> row : rows)

--- a/src/timeit_gtkmm/GUI/Details.h
+++ b/src/timeit_gtkmm/GUI/Details.h
@@ -49,6 +49,7 @@ public:
 	void on_menu_file_popup_edit();
 	void on_menu_file_popup_remove();
 	void on_menu_file_popup_merge();
+	void on_menu_file_popup_split();
 	//EventObserver interface
 	virtual void on_taskAdded(int64_t)
 	{
@@ -102,6 +103,7 @@ private:
 	time_t m_startTime;
 	time_t m_stopTime;
 	Gtk::Menu m_Menu_Popup;
+	Glib::RefPtr<Gtk::MenuItem> m_split_menu_item;
 	std::list<DetailsObserver*> observers;
 	TimeAccessor     m_timeAccessor;
 	TaskAccessor     m_taskAccessor;


### PR DESCRIPTION
The purpose is to allow splitting of timespans that run over midnight.

Over midnight timespans are split at midnight.  Others are split halfway.

If less than two minutes, then the menu item is disabled.

That logic could be changed, but it has purpose as is.